### PR TITLE
KUPC2020 春　案内ページ

### DIFF
--- a/src/ContestInfo.js
+++ b/src/ContestInfo.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import './ContestInfo.css'
+import './OnlineInfo.css'
 import OnsiteInfo from './OnsiteInfo';
+import OnlineInfo from './OnlineInfo';
 import Footer from './Footer';
 import Title from './Title';
 import Menu from './Menu';
@@ -42,7 +44,10 @@ class UpcomingContestInfo extends Component {
             <p>KUPC{suffix} は <strong>{data.date.getFullYear()}年{data.date.getMonth()+1}月{data.date.getDate()}日</strong> に行われます</p>
           : ''}
         </div>
-        <OnsiteInfo data={data} className={classes} />
+        {'online_only' in data && data.online_only === true ?
+           <OnlineInfo data={data} className={classes} />
+         : <OnsiteInfo data={data} className={classes} />
+        }
         {'links' in data ?
           <div className="links">
             <h3>コンテストページ</h3>

--- a/src/OnlineInfo.js
+++ b/src/OnlineInfo.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+import './OnlineInfo.css'
+import ClassNames from 'classnames';
+
+class OnlineInfo extends Component {
+  render() {
+    const data = this.props.data;
+    return (
+      <div className={ClassNames("OnlineInfo", this.props.className)}>
+        <div className="participate">
+          <h3>参加方法</h3>
+          <ol>
+            <li>
+              <h4>オンライン参加</h4>
+              <div>
+                <p>オンサイトでの開催はございません．そのため，事前申し込みの必要はございません．</p>
+                <p><a href={data.url_open_contest}>コンテストページ</a> より直接ご参加下さい．</p>
+              </div>
+            </li>
+          </ol>
+        </div>
+      </div>
+    );
+  }
+}
+
+export default OnlineInfo;

--- a/src/OnlineInfo.less
+++ b/src/OnlineInfo.less
@@ -1,0 +1,88 @@
+h4 {
+  margin: 0;
+}
+.Stripe(@color, @size) {
+  @color2: white;
+  background-color: @color;
+  background-image: linear-gradient(
+    -45deg,
+    @color2 25%,
+    @color 25%, @color 50%,
+    @color2 50%, @color2 75%,
+    @color 75%, @color
+  );
+  background-size: @size @size;
+}
+.participate {
+  margin: 0;
+  padding: 0 !important;
+  > ol {
+    list-style: none;
+    margin: 0;
+    padding-left: 0;
+    > li {
+      padding-bottom: 5px;
+      > h4 {
+        padding: 5px 0;
+        font-size: 18px;
+        color: white;
+      }
+    }
+    > li:first-child {
+      .Stripe(hsl(0, 60%, 93%), 3px);
+      > h4 {
+        background-color: hsl(0, 50%, 45%);
+      }
+    }
+    > li:last-child {
+      .Stripe(hsl(230, 60%, 93%), 3px);
+      > h4 {
+        background-color: hsl(230, 50%, 45%);
+      }
+    }
+  }
+}
+.list-with-icon {
+  list-style: none;
+  margin: 10px 0;
+  padding-left: 0;
+  > li {
+    margin: 15px 0;
+    > a {
+      @height: 70px;
+      display: inline-block;
+      height: @height;
+      line-height: @height;
+      color: black;
+      text-decoration: none;
+      border: 1px solid hsl(0, 0%, 90%);
+      padding: 0 12px;
+      // box-shadow: inset -3px -3px 9px -8px black;
+      // box-shadow: 3px 3px 9px -8px black;
+      position: relative;
+      transition: all .2s;
+      background-color: white;
+      &::after {
+        content: '';
+        position: absolute;
+        top: 0; left: 0;
+        width: 100%; height: 100%;
+        background-color: hsla(160, 60%, 40%, 0);
+        transition: all .2s;
+      }
+      &:hover {
+        border-color: hsl(160, 60%, 85%);
+      }
+      &:hover::after {
+        background-color: hsla(160, 60%, 40%, 0.05);
+      }
+      > img {
+        @size: 66px;
+        width: @size;
+        height: @size;
+        margin-right: 10px;
+        float: left;
+      }
+    }
+  }
+}

--- a/src/data.js
+++ b/src/data.js
@@ -29,6 +29,17 @@ const Data = {
     // },
     {
       component: ContestInfo,
+      suffix: '2020 春',
+      date: '2020-03-20',
+      online_only: true,
+      url_open_contest: 'https://onlinejudge.u-aizu.ac.jp/beta/room.html#KUPC2020Spring/info',
+      links: [
+        { title: "コンテストページ", url: "https://onlinejudge.u-aizu.ac.jp/beta/room.html#KUPC2020Spring/info" },
+      ],
+      staffs: ['大森 智仁', '加藤 剛', '角野 祐弥', '曽根 大雅', '中野 瑛一', '西川 剛史', '増田 舜大', '松本 和彦', '森 順平', '山岡 宙太', '山崎 宏紀', '脇坂 遼'],
+    },
+    {
+      component: ContestInfo,
       suffix: '2019',
       date: '2019-10-13',
       links: [


### PR DESCRIPTION
修正点

- kupc2020 春のリンクを追加
- `online_only` メンバーを追加し，表示を分岐